### PR TITLE
Fix nil index issue with premake.make

### DIFF
--- a/_preload.lua
+++ b/_preload.lua
@@ -6,7 +6,7 @@
 
 premake.extensions.androidmk = premake.extensions.androidmk or {}
 local androidmk = premake.extensions.androidmk
-local make = premake.make
+local make = premake.make or {}
 
 
 androidmk.CONFIG_OPTION = "PM5_CONFIG"


### PR DESCRIPTION
Getting this error now:

```
Error: .../premake-androidmk/_preload.lua:29: attempt to index a nil value (upvalue 'make')
```

Perhaps a compatibility issue with newer premake versions?
Adding `or {}` works.

Premake version: 5.0.0-alpha14